### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Converts MySQL dump to SQLite3 compatible dump (including MySQL `KEY xxxxx` stat
     ~~~~
 mysqldump --skip-extended-insert --compact [options]... DB_name
 # or
-#mysqldump --no-data -u root -pmyPassword [options]... DB_name
+# mysqldump --no-data -u root -pmyPassword [options]... DB_name
 ~~~~
 
 1. Convert the dump to SQLite3 DB


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
