### PR TITLE
Adding primitive extra white space tolerance

### DIFF
--- a/mysql2sqlite
+++ b/mysql2sqlite
@@ -181,11 +181,11 @@ END {
   print "END TRANSACTION;"
 
   if ( hexIssue ){
-    print "WARN Hexadecimal numbers longer than 16 characters has been trimmed." | "cat >&2"
+    print "WARN Hexadecimal numbers longer than 16 characters have been trimmed." | "cat >&2"
   }
   if ( caseIssue ){
     print "WARN Pure sqlite identifiers are case insensitive (even if quoted\n" \
-          "     or if ASCII) and doesnt cross-check TABLE and TEMPORARY TABLE\n" \
+          "     or if ASCII) and do not cross-check TABLE and TEMPORARY TABLE\n" \
           "     identifiers. Thus expect errors like \"table T has no column named F\"." | "cat >&2"
   }
 }

--- a/mysql2sqlite
+++ b/mysql2sqlite
@@ -18,7 +18,7 @@ BEGIN {
 
 # Declare white-space only lines as empty
 {
-    if ( match( prev, /^\s+$/ ) ) {
+    if ( match( prev, /^[[:space:]]+$/ ) ) {
         prev=""
     }
 }

--- a/mysql2sqlite
+++ b/mysql2sqlite
@@ -16,6 +16,13 @@ BEGIN {
   print "BEGIN TRANSACTION;"
 }
 
+# Declare white-space only lines as empty
+{
+    if ( match( prev, /^\s+$/ ) ) {
+        prev=""
+    }
+}
+
 # CREATE TRIGGER statements have funny commenting. Remember we are in trigger.
 /^\/\*.*(CREATE.*TRIGGER|create.*trigger)/ {
   gsub( /^.*(TRIGGER|trigger)/, "CREATE TRIGGER" )
@@ -105,7 +112,7 @@ aInc == 1 && /PRIMARY KEY|primary key/ { next }
   gsub( /(ENUM|enum)[^)]+\)/, "text " )
   gsub( /(SET|set)\([^)]+\)/, "text " )
   gsub( /UNSIGNED|unsigned/, "" )
-  gsub( /` [^ ]*(INT|int)[^ ]*/, "` integer" )
+  gsub( /` +[^ ]*(INT|int)[^ ]*/, "` integer" )
   # field comments are not supported
   gsub( / (COMMENT|comment).+$/, "" )
   # Get commas off end of line


### PR DESCRIPTION
Mishandling of extra white space symbols caused some MySQL statements to be interpreted incorrectly, i.e.:

```
CREATE TABLE `sample` (
  `id`           int(11)      AUTO_INCREMENT NOT NULL
        COMMENT 'unique table key',
  `example`      char(36)     DEFAULT NULL
        COMMENT 'example field',
)  ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci
;
```
results in 

```
BEGIN TRANSACTION;
CREATE TABLE `sample` (
  `id`           int(11)      PRIMARY KEY AUTOINCREMENT NOT NULL
,       
,  `example`      char(36)     DEFAULT NULL
,       
);
END TRANSACTION;
```

Of course, it is unlikely that a software-facilitated dump would produce extra white-spaces, but the handling of such situations might prove useful when dealing with hand-crafted statements.  If this change is in conformance with the scope of this script, the same white-space lenience should be expanded to other regexes as well.