### PR TITLE
fix escaping of seqences of even number of backslashes

### DIFF
--- a/mysql2sqlite
+++ b/mysql2sqlite
@@ -103,14 +103,21 @@ inView != 0 { next }
 # print all INSERT lines
 ( /^ *\(/ && /\) *[,;] *$/ ) || /^(INSERT|insert)/ {
   prev = ""
+
+  # first replace \\ by \_ that mysqldump never generates to deal with
+  # sequnces like \\n that should be translated into \n, not \<LF>.
+  # After we convert all escapes we replace \_ by backslashes.
+  gsub( /\\\\/, "\\_" )
+
   # single quotes are escaped by another single quote
   gsub( /\\'/, "''" )
-  gsub( /\\'',/, "\\'," )
   gsub( /\\n/, "\n" )
   gsub( /\\r/, "\r" )
   gsub( /\\"/, "\"" )
-  gsub( /\\\\/, "\\" )
   gsub( /\\\032/, "\032" )  # substitute char
+
+  gsub( /\\_/, "\\" )
+
   # sqlite3 is limited to 16 significant digits of precision
   while( match( $0, /0x[0-9a-fA-F]{17}/ ) ){
     hexIssue = 1
@@ -221,8 +228,8 @@ aInc == 1 && /PRIMARY KEY|primary key/ { next }
   print ");"
   next
 }
-# `KEY` lines are extracted from the `CREATE` block and stored in array for later print 
-# in a separate `CREATE KEY` command. The index name is prefixed by the table name to 
+# `KEY` lines are extracted from the `CREATE` block and stored in array for later print
+# in a separate `CREATE KEY` command. The index name is prefixed by the table name to
 # avoid a sqlite error for duplicate index name.
 /^(  (KEY|key)|\);)/ {
   if( prev ){


### PR DESCRIPTION
The real issue is that the even number of backslashes followed by x is not an escape for x, but just a sequence of backslash escapes. To deal with that replace `\\` by `\_`  that mysqldump output cannot contain, then do gsub calls to replace escapes and only at the end replace `\_` by `\`.