### PR TITLE
Fix double quotes for KEY

### DIFF
--- a/mysql2sqlite
+++ b/mysql2sqlite
@@ -146,7 +146,7 @@ inView != 0 { next }
       NR ": WARN Potential case sensitivity issues with table/column naming\n" \
       "          (see INFO at the end)." )
   }
-  if( match( $0, /`[^`]+/ ) ){
+  if( match( $0, /["`][^"`]+/ ) ){
     tableName = substr( $0, RSTART+1, RLENGTH-1 )
   }
   aInc = 0
@@ -249,7 +249,7 @@ aInc == 1 && /PRIMARY KEY|primary key/ { next }
     print
   }
   else {
-    if( match( $0, /`[^`]+/ ) ){
+    if( match( $0, /["`][^"`]+/ ) ){
       indexName = substr( $0, RSTART+1, RLENGTH-1 )
     }
     if( match( $0, /\([^()]+/ ) ){

--- a/mysql2sqlite
+++ b/mysql2sqlite
@@ -207,13 +207,6 @@ aInc == 1 && /PRIMARY KEY|primary key/ { next }
       print "," prev
     }
   }
-  else {
-    # FIXME check if this is correct in all cases
-    if( match( $1,
-        /(CONSTRAINT|constraint) \".*\" (FOREIGN KEY|foreign key)/ ) ){
-      print ","
-    }
-  }
   prev = $1
 }
 


### PR DESCRIPTION
Given the following DDL:
```sql
CREATE TABLE "foo1" (
  "col1" varchar(255),
  KEY "key1" ("x"),
  CONSTRAINT "constraint1" FOREIGN KEY ("fk1") REFERENCES "foo2" ("col2")
);
```
mysql2sqlite emits (1) a malformed CREATE INDEX statement, and (2) a line containing only a comma before the CONSTRAINT:
```sql
PRAGMA synchronous = OFF;
PRAGMA journal_mode = MEMORY;
BEGIN TRANSACTION;
CREATE TABLE "foo1" (
  "col1" varchar(255)
,
,  CONSTRAINT "constraint1" FOREIGN KEY ("fk1") REFERENCES "foo2" ("col2")
);
CREATE INDEX "idx__" ON "" ("x");
END TRANSACTION;
```
This patch addresses both of these issues.

