### PR TITLE
handle varied letter casing of current_timestamp and optional parens

### DIFF
--- a/mysql2sqlite
+++ b/mysql2sqlite
@@ -183,7 +183,8 @@ aInc == 1 && /PRIMARY KEY|primary key/ { next }
   #   BEGIN
   #   UPDATE Package SET LastUpdate = CURRENT_TIMESTAMP WHERE ActionId = old.ActionId;
   #   END
-  gsub( /ON UPDATE CURRENT_TIMESTAMP|on update current_timestamp/, "" )
+  gsub( /ON UPDATE (CURRENT_TIMESTAMP|current_timestamp)(\(\))?/, "" )
+  gsub( /(DEFAULT|default) (CURRENT_TIMESTAMP|current_timestamp)(\(\))?/, "DEFAULT current_timestamp")
   gsub( /(COLLATE|collate) [^ ]+ /, "" )
   gsub( /(ENUM|enum)[^)]+\)/, "text " )
   gsub( /(SET|set)\([^)]+\)/, "text " )

--- a/mysql2sqlite
+++ b/mysql2sqlite
@@ -183,7 +183,7 @@ aInc == 1 && /PRIMARY KEY|primary key/ { next }
   #   BEGIN
   #   UPDATE Package SET LastUpdate = CURRENT_TIMESTAMP WHERE ActionId = old.ActionId;
   #   END
-  gsub( /ON UPDATE (CURRENT_TIMESTAMP|current_timestamp)(\(\))?/, "" )
+  gsub( /(ON|on) (UPDATE|update) (CURRENT_TIMESTAMP|current_timestamp)(\(\))?/, "" )
   gsub( /(DEFAULT|default) (CURRENT_TIMESTAMP|current_timestamp)(\(\))?/, "DEFAULT current_timestamp")
   gsub( /(COLLATE|collate) [^ ]+ /, "" )
   gsub( /(ENUM|enum)[^)]+\)/, "text " )

--- a/unit_tests.sh
+++ b/unit_tests.sh
@@ -101,5 +101,25 @@ cat <<\SQL
  PARTITION p7 VALUES LESS THAN (2013) ENGINE = InnoDB)
 SQL
 
+cat <<\SQLin
+CREATE TABLE `CCC`(
+  `created` datetime DEFAULT current_timestamp(),
+  `updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp()
+);
+SQLin
+
+cat <<\SQLout
+PRAGMA synchronous = OFF;
+PRAGMA journal_mode = MEMORY;
+BEGIN TRANSACTION;
+CREATE TABLE `CCC`(
+  `created` datetime DEFAULT current_timestamp
+,  `updated` datetime DEFAULT current_timestamp 
+);
+END TRANSACTION;
+SQLout
+
+
 cat <<\SQL
 SQL
+


### PR DESCRIPTION
I found that the `mysql2sqlite` script was not handling the following input properly (from `mysqldump` where `VERSION()` is 10.3.9-MariaDB):

```
  `created` datetime DEFAULT current_timestamp(),
  `updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
```

... so I adjusted the regex to handle "current_timestamp" being upper or lower case, and parentheses are optional after.

This change overlaps https://github.com/dumblob/mysql2sqlite/pull/42

Side note: I attempted to update unit_tests.sh but the file has a `# FIXME` and exits immediately.