### PR TITLE
Fix for when there is no "ENGINE" statement.

### DIFF
--- a/mysql2sqlite
+++ b/mysql2sqlite
@@ -218,7 +218,7 @@ aInc == 1 && /PRIMARY KEY|primary key/ { next }
   prev = $1
 }
 
-/ ENGINE| engine/ {
+/ ENGINE| engine|\);/ {
   if( prev ){
     if( firstInTable ){
       print prev


### PR DESCRIPTION
The Regex has been changed from  

> / ENGINE| engine/ 

to  

> / ENGINE| engine| \\);/ 

This way, when the "ENGINE" keyword isn't present, it will still print out the closing ");" for the table create.  

Tested on dumps with ENGINE and without, working.