### PR TITLE
work around mawk's lack of repetition support

### DIFF
--- a/mysql2sqlite
+++ b/mysql2sqlite
@@ -122,7 +122,8 @@ inView != 0 { next }
   gsub( /\\_/, "\\" )
 
   # sqlite3 is limited to 16 significant digits of precision
-  while( match( $0, /0x[0-9a-fA-F]{17}/ ) ){
+  # we repeat the regex 17 times instead of using {17} for mawk compatibility
+  while( match( $0, /0x[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]/ ) ){
     hexIssue = 1
     sub( /0x[0-9a-fA-F]+/, substr( $0, RSTART, RLENGTH-1 ), $0 )
   }


### PR DESCRIPTION
`mawk` does not support brace expressions for repetition. See: https://github.com/ThomasDickey/original-mawk/issues/25

This change works around the problem by just repeating the match group the desired number of times. 

You can see the fix in action on the tests in my branch here https://github.com/frrad/mysql2sqlite/pull/3/files.

I also think that it's perfectly justifiable to not support mawk since this is pretty gross. If you decide to go this road though it might be nice to call it out in the README which currently says that mawk "should work"