### PR TITLE
remove escaping of quotes

### DIFF
--- a/mysql2sqlite
+++ b/mysql2sqlite
@@ -211,7 +211,7 @@ aInc == 1 && /PRIMARY KEY|primary key/ { next }
   else {
     # FIXME check if this is correct in all cases
     if( match( $1,
-        /(CONSTRAINT|constraint) \".*\" (FOREIGN KEY|foreign key)/ ) ){
+        /(CONSTRAINT|constraint) ".*" (FOREIGN KEY|foreign key)/ ) ){
       print ","
     }
   }


### PR DESCRIPTION
According to https://www.gnu.org/software/gawk/manual/html_node/Escape-Sequences.html the `"` need only be escaped as `\"` in string constants. 

I suspect from [googling](https://www.google.com/search?&q=gawk+5+"regexp+escape+sequence"+"is+not+a+known") (though cannot confirm) that in gawk 5.0+ this escaping causes a warning.

I have also [checked](https://github.com/frrad/mysql2sqlite/pull/4) that this PR causes no regression in the existing tests.

@jagarsoft Can you confirm that this patch fixes your problem on gawk 5?