### PR TITLE
Fix fulltext matching

### DIFF
--- a/mysql2sqlite
+++ b/mysql2sqlite
@@ -157,7 +157,7 @@ inView != 0 { next }
 }
 
 # Replace `FULLTEXT KEY` (probably other `XXXXX KEY`)
-/^  (FULLTEXT KEY|fulltext key)/ { gsub( /.+(KEY|key)/, "  KEY" ) }
+/^  (FULLTEXT KEY|fulltext key)/ { gsub( /[A-Za-z ]+(KEY|key)/, "  KEY" ) }
 
 # Get rid of field lengths in KEY lines
 / (PRIMARY |primary )?(KEY|key)/ { gsub( /\([0-9]+\)/, "" ) }


### PR DESCRIPTION
If the index name on a fulltext key contains the string `key`, then the `.+` pattern greedily matches too far into the string and produces an invalid line. This fix will correctly replace `  FULLTEXT KEY` with `  KEY` regardless of the contents of the index name.