### PR TITLE
Fix columsn with utc_timestamp default

### DIFF
--- a/mysql2sqlite
+++ b/mysql2sqlite
@@ -167,6 +167,9 @@ inView != 0 { next }
 # Get rid of field lengths in KEY lines
 / (PRIMARY |primary )?(KEY|key)/ { gsub( /\([0-9]+\)/, "" ) }
 
+# Replace utc_timestamp with CURRENT_TIMESTAMP.  utc_timestamp does not exist on sqlite but sqlites CURRENT_TIMESTAMP uses utc timezone.
+/ (utc_timestamp)/ { gsub( /utc_timestamp/, "current_timestamp" ) }
+
 aInc == 1 && /PRIMARY KEY|primary key/ { next }
 
 # Replace COLLATE xxx_xxxx_xx statements with COLLATE BINARY

--- a/mysql2sqlite
+++ b/mysql2sqlite
@@ -9,8 +9,13 @@ function printerr( s ){ print s | "cat >&2" }
 BEGIN {
   if( ARGC != 2 ){
     printerr( \
-      "USAGE: mysql2sqlite dump_mysql.sql > dump_sqlite3.sql\n" \
-      "       file name - (dash) is not supported, because - means stdin")
+      "USAGE:\n"\
+      "       - mysql2sqlite dump_mysql.sql > dump_sqlite3.sql\n" \
+      "       OR\n" \
+      "       - mysql2sqlite dump_mysql.sql | sqlite3 sqlite.db\n" \
+      "\n" \
+      "NOTES:\n" \
+      "       - Dash in filename is not supported, because dash (-) means stdin.")
     no_END = 1
     exit 1
   }


### PR DESCRIPTION
Replace `utc_timestamp` with `CURRENT_TIMESTAMP`.

MySQL allows using `UTC_TIMESTAMP` as the default value for a column (i.e. `DatetimeCreated DATETIME DEFAULT UTC_TIMESTAMP`).  This is useful in MySQL since the timezone of the default value will always be UTC.  Compare this against using `CURRENT_TIMESTAMP` where the timezone of the default value will be the timezone of the system or server.

`UTC_TIMESTAMP` does not exists in SQLite; SQLite only uses `CURRENT_TIMESTAMP` and it returns a value in the UTC timezone.  So if we want to convert from MySQL to SQLite, we need to convert `UTC_TIMESTAMP` to `CURRENT_TIMESTAMP`.
