### PR TITLE
skip only if the word CREATE is followed by the word DATABASE

### DIFF
--- a/mysql2sqlite
+++ b/mysql2sqlite
@@ -141,7 +141,7 @@ inView != 0 { next }
 }
 
 # CREATE DATABASE is not supported
-/^(CREATE.*DATABASE|create.*database)/ { next }
+/^(CREATE DATABASE|create database)/ { next }
 
 # print the CREATE line as is and capture the table name
 /^(CREATE|create)/ {


### PR DESCRIPTION
skip only if the word CREATE is followed by the word DATABASE to prevent skipping names with the word DATABASE in them

for example, right now the situation is that:
`CREATE TABLE 'PIZZA_DATABASE'`
will be skipped.