### PR TITLE
Missing ' \( ' in ' enum ' replacement

### DIFF
--- a/mysql2sqlite
+++ b/mysql2sqlite
@@ -191,7 +191,7 @@ aInc == 1 && /PRIMARY KEY|primary key/ { next }
   gsub( /(ON|on) (UPDATE|update) (CURRENT_TIMESTAMP|current_timestamp)(\(\))?/, "" )
   gsub( /(DEFAULT|default) (CURRENT_TIMESTAMP|current_timestamp)(\(\))?/, "DEFAULT current_timestamp")
   gsub( /(COLLATE|collate) [^ ]+ /, "" )
-  gsub( /(ENUM|enum)[^)]+\)/, "text " )
+  gsub( /(ENUM|enum)\([^)]+\)/, "text " )
   gsub( /(SET|set)\([^)]+\)/, "text " )
   gsub( /UNSIGNED|unsigned/, "" )
   gsub( /_utf8mb3/, "" )


### PR DESCRIPTION
The missing ' \( ' did break our schema with column name `print_seitenumbruch`. The string contains 'enum' that got replaced to ' `print_seittext  NOT NULL DEFAULT 0'.